### PR TITLE
small fixes on ioutil and error handling

### DIFF
--- a/end2end_test.go
+++ b/end2end_test.go
@@ -28,11 +28,11 @@ func TestEnd2End(t *testing.T) {
 
 			var ctxt context
 			ctxt.paths = []string{rel}
-			ctxt.initCheckers()
+			_ = ctxt.initCheckers()
 			if err := ctxt.collectAllCandidates(); err != nil {
 				t.Fatalf("collect candidates: %v", err)
 			}
-			ctxt.assignSuggestions()
+			_ = ctxt.assignSuggestions()
 			visitWarnings(&ctxt, func(pos token.Position, v *opVariant) {
 				text := v.op.name + ": " + v.op.suggested.warning
 				mlist, ok := f.Matchers[pos.Line]

--- a/internal/end2end/end2end.go
+++ b/internal/end2end/end2end.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"go/token"
 	"io"
-	"io/ioutil"
+	"os"
 	"regexp"
 )
 
 // ParseTestFile parses file at specified path using the parser with default settings.
 func ParseTestFile(filename string) (*TestFile, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("read test file: %v", err)
 	}
@@ -82,7 +82,7 @@ type TestParser struct {
 
 // ParseFile parses everything from r using filename to make associations.
 func (p *TestParser) ParseFile(filename string, r io.Reader) (*TestFile, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("read test file: %v", err)
 	}

--- a/internal/end2end/end2end.go
+++ b/internal/end2end/end2end.go
@@ -12,7 +12,7 @@ import (
 func ParseTestFile(filename string) (*TestFile, error) {
 	data, err := os.ReadFile(filename)
 	if err != nil {
-		return nil, fmt.Errorf("read test file: %v", err)
+		return nil, fmt.Errorf("read test file: %w", err)
 	}
 	var p TestParser
 	return p.parseFile(filename, data)
@@ -84,7 +84,7 @@ type TestParser struct {
 func (p *TestParser) ParseFile(filename string, r io.Reader) (*TestFile, error) {
 	data, err := io.ReadAll(r)
 	if err != nil {
-		return nil, fmt.Errorf("read test file: %v", err)
+		return nil, fmt.Errorf("read test file: %w", err)
 	}
 	return p.parseFile(filename, data)
 }

--- a/internal/end2end/parser.go
+++ b/internal/end2end/parser.go
@@ -23,7 +23,7 @@ func (p *TestParser) parseFile(filename string, data []byte) (*TestFile, error) 
 			case "~":
 				re, err := regexp.Compile(text)
 				if err != nil {
-					return nil, fmt.Errorf("%s:%d: %v", filename, line, err)
+					return nil, fmt.Errorf("%s:%d: %w", filename, line, err)
 				}
 				m.re = re
 			case "=":

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"go/ast"
@@ -89,7 +90,7 @@ func (ctxt *context) parseFlags() error {
 
 	ctxt.flags.targets = flag.Args()
 	if len(ctxt.flags.targets) == 0 {
-		return fmt.Errorf("not enough positional args (empty targets list)")
+		return errors.New("not enough positional args (empty targets list)")
 	}
 
 	if ctxt.flags.shorterErrLocation {
@@ -106,13 +107,13 @@ func (ctxt *context) parseFlags() error {
 func (ctxt *context) resolveTargets() error {
 	ctxt.paths = gotool.ImportPaths(ctxt.flags.targets)
 	if len(ctxt.paths) == 0 {
-		return fmt.Errorf("targets resolved to an empty import paths list")
+		return errors.New("targets resolved to an empty import paths list")
 	}
 
 	// Filter-out packages using the exclude pattern.
 	excludeRE, err := regexp.Compile(ctxt.flags.exclude)
 	if err != nil {
-		return fmt.Errorf("compiling -exclude regexp: %v", err)
+		return fmt.Errorf("compiling -exclude regexp: %w", err)
 	}
 	paths := ctxt.paths[:0]
 	for _, path := range ctxt.paths {
@@ -179,7 +180,7 @@ func (ctxt *context) collectAllCandidates() error {
 	for _, path := range ctxt.paths {
 		ctxt.infoPrintf("check %q", path)
 		if err := ctxt.collectPathCandidates(path); err != nil {
-			return fmt.Errorf("%s: %v", path, err)
+			return fmt.Errorf("%s: %w", path, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Here I am

- using `io` and `os` packages instead `io/ioutil` package - it is deprecated
- using `errors.New` instead `fmt.Errorf` when there is no parameters to format
- using `%w` instead `%v` when using `fmt.Errort` when wrapping an existing error
- set unused errors in tests to `_`

enjoy