### PR TITLE
readme: fix installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Source code analyzer that helps you to make your Go programs more consistent.
 This install the `go-consistent` binary:
 
 ```bash
-go install github.com/quasilyte/go-consistent
+go install github.com/quasilyte/go-consistent@latest
 ```
 
 If go install location is under your system `$PATH`, `go-consistent` command should be available after that.<br>


### PR DESCRIPTION
Without explicit `@<ref>` (`@latest`, `@master`, `@v0.6.1`) the go command can't install a tool.